### PR TITLE
Add support for InfluxDB 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Role Variables
 
 | Name                        | Default Value | Description                                                      |
 |-----------------------------|---------------|------------------------------------------------------------------|
-| influxdb.version            | 0.5.4         | Version to install                                               |
 | influxdb.raft_port          | [8090]        | Port used for raft                                               |
 | influxdb.seed_servers       | []            | List of host:port to use as cluster seed servers                 |
 | influxdb.replication_factor | 1             | How many servers in the cluster should have a copy of each shard |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 influxdb:
-  version: 0.8.1
   raft_port: 8090
   seed_servers: [ ]
   replication_factor: 1
@@ -7,6 +6,7 @@ influxdb:
 influxdb_client_port: 8086
 influxdb_hostname: "{{ ansible_default_ipv4.address }}"
 influxdb_bind_address: 0.0.0.0
+influxdb_version: 0.8.8
 
 influxdb_use_apt: false
 # Url to find the influxdb deb, the deb name/version is appended, only used if not using apt

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,11 +3,11 @@
   when: influxdb_use_apt
 
 - name: Fetch package
-  get_url: url={{influxdb_deb_src_url}}/influxdb_{{ influxdb.version }}_amd64.deb dest=/usr/local/src/influxdb_{{ influxdb.version }}_amd64.deb
+  get_url: url={{influxdb_deb_src_url}}/influxdb_{{ influxdb_version }}_amd64.deb dest=/usr/local/src/influxdb_{{ influxdb_version }}_amd64.deb
   when: not influxdb_use_apt
 
 - name: Install package
-  command: dpkg --skip-same-version -i /usr/local/src/influxdb_{{ influxdb.version }}_amd64.deb
+  command: dpkg --skip-same-version -i /usr/local/src/influxdb_{{ influxdb_version }}_amd64.deb
   register: dpkg_result
   changed_when: "dpkg_result.stdout.startswith('Selecting')"
   when: not influxdb_use_apt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Update config (0.8.x)
   template: src=config.toml dest=/opt/influxdb/shared/config.toml
-  when: influxdb.version|version_compare('0.9', '<=')
+  when: influxdb.version|version_compare('0.9', '<')
   notify:
     - restart influxdb
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
 
 - name: Update config (0.8.x)
   template: src=config.toml dest=/opt/influxdb/shared/config.toml
-  when: influxdb.version|search("0\.8\..*")
+  when: influxdb.version|version_compare('0.9', '<=')
   notify:
     - restart influxdb
 
 - name: Update config (0.9.x)
   template: src=influxdb.conf dest=/etc/opt/influxdb/influxdb.conf
-  when: influxdb.version|search("0\.9\..*")
+  when: influxdb.version|version_compare('0.9', '>=')
   notify:
     - restart influxdb
     

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
 
 - name: Update config (0.8.x)
   template: src=config.toml dest=/opt/influxdb/shared/config.toml
-  when: influxdb.version|version_compare('0.9', '<')
+  when: influxdb_version|version_compare('0.9', '<')
   notify:
     - restart influxdb
 
 - name: Update config (0.9.x)
   template: src=influxdb.conf dest=/etc/opt/influxdb/influxdb.conf
-  when: influxdb.version|version_compare('0.9', '>=')
+  when: influxdb_version|version_compare('0.9', '>=')
   notify:
     - restart influxdb
     

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,15 @@
 - include: install.yml
   when: not skip_install
 
-- name: Update config
+- name: Update config (0.8.x)
   template: src=config.toml dest=/opt/influxdb/shared/config.toml
+  when: influxdb.version|search("0\.8\..*")
+  notify:
+    - restart influxdb
+
+- name: Update config (0.9.x)
+  template: src=influxdb.conf dest=/etc/opt/influxdb/influxdb.conf
+  when: influxdb.version|search("0\.9\..*")
   notify:
     - restart influxdb
     

--- a/templates/influxdb.conf
+++ b/templates/influxdb.conf
@@ -1,0 +1,94 @@
+# Welcome to the InfluxDB configuration file.
+
+# If hostname (on the OS) doesn't return a name that can be resolved by the other
+# systems in the cluster, you'll have to set the hostname to an IP or something
+# that can be resolved here.
+hostname = "{{ influxdb_hostname }}"
+bind-address = "0.0.0.0"
+
+# Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
+# The data includes raft id (random 8 bytes), os, arch and version
+# We don't track ip addresses of servers reporting. This is only used
+# to track the number of instances running and the versions, which
+# is very helpful for us.
+# Change this option to true to disable reporting.
+reporting-disabled = true
+
+# Controls settings for initial start-up. Once a node a successfully started,
+# these settings are ignored.
+[initialization]
+join-urls = "" # Comma-delimited URLs, in the form http://host:port, for joining another cluster. 
+
+# Control authentication
+# If not set authetication is DISABLED. Be sure to explicitly set this flag to
+# true if you want authentication.
+[authentication]
+enabled = false
+
+# Configure the admin server
+[admin]
+enabled = true
+port = 8083
+
+# Configure the HTTP API endpoint. All time-series data and queries uses this endpoint.
+[api]
+{% if influxdb_ssl_certificate is defined %}
+ssl-port = {{influxdb_client_port}}    # Ssl support is enabled if you set a port and cert
+ssl-cert = "{{influxdb_ssl_certificate}}"
+{% else %}
+port     = {{influxdb_client_port}}    # binding is disabled if the port isn't set
+{% endif %}
+
+# Configure the Graphite plugins.
+[[graphite]] # 1 or more of these sections may be present.
+enabled = false
+# protocol = "" # Set to "tcp" or "udp"
+# address = "0.0.0.0" # If not set, is actually set to bind-address.
+# port = 2003
+# name-position = "last"
+# name-separator = "-"
+# database = ""  # store graphite data in this database
+
+# Configure the collectd input.
+[collectd]
+enabled = false
+#address = "0.0.0.0" # If not set, is actually set to bind-address.
+#port = 25827
+#database = "collectd_database"
+#typesdb = "types.db"
+
+# Configure UDP listener for series data.
+[udp]
+enabled = false
+#bind-address = "0.0.0.0"
+#port = 4444
+
+# Broker configuration. Brokers are nodes which participate in distributed
+# consensus.
+[broker]
+# Where the Raft logs are stored. The user running InfluxDB will need read/write access.
+dir  = "/opt/influxdb/shared/data/raft"
+port = {{influxdb.raft_port}}
+
+# Data node configuration. Data nodes are where the time-series data, in the form of
+# shards, is stored.
+[data]
+  dir = "/opt/influxdb/shared/data/db"
+  port = {{influxdb_client_port}}
+
+  # Auto-create a retention policy when a database is created. Defaults to true.
+  retention-auto-create = true
+
+  # Control whether retention policies are enforced and how long the system waits between
+  # enforcing those policies.
+  retention-check-enabled = true
+  retention-check-period = "10m"
+
+[cluster]
+# Location for cluster state storage. For storing state persistently across restarts.
+dir = "/opt/influxdb/shared/state"
+
+[logging]
+file   = "/var/log/influxdb/influxd.log" # Leave blank to redirect logs to stderr.
+write-tracing = false # If true, enables detailed logging of the write system.
+raft-tracing = false # If true, enables detailed logging of Raft consensus.


### PR DESCRIPTION
If influxdb.version is set to 0.9.x (currently tested with 0.9.0-rc10),
a different configuration file is necessary and will be installed
from the new template.
