### PR TITLE
Make it work if the file had already been downloaded

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,9 +3,9 @@
   when: influxdb_use_apt
 
 - name: Fetch package
-  get_url: url={{influxdb_deb_src_url}}/influxdb_{{ influxdb_version }}_amd64.deb dest=/usr/local/src/influxdb_{{ influxdb_version }}_amd64.deb timeout=30
+  get_url: url={{influxdb_deb_src_url}}/influxdb_{{ influxdb_version }}_amd64.deb dest=/usr/local/src/influxdb_{{ influxdb_version }}_amd64.deb
   register: get_url_result
-  until: "'OK' in get_url_result.msg"
+  until: get_url_result.state == 'file'
   retries: 5
   delay: 1
   when: not influxdb_use_apt


### PR DESCRIPTION
Remove the timeout as that seemed to cause issues on some
systems
